### PR TITLE
Feature/defect fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,5 @@ install:
   - npm run testrpc
 
 script:
-  - npm run truffle-test
-  - npm test
+  - npm run test:all
   - npm run coverage

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/TransmuteFramework.js",
   "scripts": {
     "clean": "rm -rf build docs coverage .nyc_output",
+    "transmute": "node cli/index.js",
     "start": "ts-node src/TransmuteFramework.ts",
     "build": "node node_modules/typescript/bin/tsc --p tsconfig.json && cp -r contracts/TransmuteFramework build/contracts/ && cp -r cli build/cli && cp -r migrations build/migrations && cp -r test build/test",
     "watch": "node node_modules/typescript/bin/tsc --w --p tsconfig.json",
@@ -13,6 +14,7 @@
     "testrpc": "pm2 start testrpc",
     "truffle-test": "truffle migrate && truffle test",
     "test": "nyc mocha",
+    "test:all": "npm run clean && npm run truffle-test && npm run test",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "docs": "typedoc --gaID UA-99768185-1 --out docs src && /usr/bin/open -a '/Applications/Google Chrome.app' docs/index.html ",
     "deploy:docs": "firebase deploy",

--- a/src/EventStoreFactory/EventStoreFactory.spec.ts
+++ b/src/EventStoreFactory/EventStoreFactory.spec.ts
@@ -5,20 +5,25 @@ import { web3 } from '../env'
 
 import { EventStoreFactory } from './EventStoreFactory'
 
-describe('EventStoreFactory', () => {
+describe.only('EventStoreFactory', () => {
 
     let factory
-    let fromAddress = web3.eth.accounts[3];
+    let fromAddress = web3.eth.accounts[0];
 
     before(async () => {
         factory = await EventStoreFactory.EventStoreFactoryContract.deployed()
     })
 
     describe('.createEventStore...', () => {
-        it('should create an event store and return event ', async () => {
-            let events = await EventStoreFactory.createEventStore(factory, fromAddress)
-            let createEvent = events[0]
-            expect(createEvent.Type === 'EVENT_STORE_CREATED')
+        it('returns a transaction', async () => {
+            let txWithEvents = await EventStoreFactory.createEventStore(factory, fromAddress)
+            expect(txWithEvents.tx === undefined)
+        })
+
+        it('returns a FACTORY_EVENT_STORE_CREATED event', async () => {
+            let txWithEvents = await EventStoreFactory.createEventStore(factory, fromAddress)
+            let createEvent = txWithEvents.events[0]
+            expect(createEvent.Type === 'FACTORY_EVENT_STORE_CREATED')
         })
     })
 

--- a/src/EventStoreFactory/EventStoreFactory.ts
+++ b/src/EventStoreFactory/EventStoreFactory.ts
@@ -13,13 +13,17 @@ export module EventStoreFactory {
     EventStoreFactoryContract.setProvider(web3.currentProvider)
 
     export const createEventStore = async (factory, fromAddress) => {
-        // console.log(factory)
+        // console.log(fromAddress)
         let tx = await factory.createEventStore({
             from: fromAddress,
             gas: 2000000
         })
+        // console.log(tx)
         let events = Transactions.transactionToEventCollection(tx)
-        return events
+        return {
+            events: events,
+            tx: tx
+        }
     }
 
     export const getAllEventStoreContractAddresses = async (factory, fromAddress) => {

--- a/src/Transactions/Transactions.ts
+++ b/src/Transactions/Transactions.ts
@@ -46,18 +46,17 @@ export module Transactions {
         })
         return allEvents
     }
-
+    // TODO: Add more rigorous testing of multiple events
+    // TODO: Add better error handling here, with instructions to make sure npm run test:all passes...
     export const transactionEventsToEventObject = (events) => {
-
-        let eventObjs = filter(events, (evt) => {
+        let eventObjs = filter(events, (evt: any) => {
             return evt.Id !== undefined
         })
-
-        eventObjs.forEach((eventObj: any) => {
+        eventObjs.forEach((eventObj) => {
             let propIndex = 0;
             while (propIndex < eventObj.PropertyCount) {
-                let eventProp = find(events, (evt) => {
-                    return evt.EventPropertyIndex === propIndex
+                let eventProp = find(events, (evt : any) => {
+                    return evt.EventPropertyIndex === propIndex && evt.EventIndex === eventObj.Id
                 })
                 let eventPropObj = EventTypes.solidityEventPropertyToObject(eventProp)
                 extend(eventObj, eventPropObj)

--- a/test/EventStore/SolidityEvent/Transactions/index.js
+++ b/test/EventStore/SolidityEvent/Transactions/index.js
@@ -36,7 +36,6 @@ const eventsFromTransaction = (tx) => {
 }
 
 
-
 const transactionEventsToEventObject = (events) => {
 
     let eventObjs = _.filter(events, (evt) => {
@@ -47,7 +46,7 @@ const transactionEventsToEventObject = (events) => {
         let propIndex = 0;
         while (propIndex < eventObj.PropertyCount) {
             let eventProp = _.find(events, (evt) => {
-                return evt.EventPropertyIndex === propIndex
+                return evt.EventPropertyIndex === propIndex && evt.EventIndex === eventObj.Id
             })
             let eventPropObj = solidityEventPropertyToObject(eventProp)
             _.extend(eventObj, eventPropObj)

--- a/test/EventStoreFactory/EventStoreFactory.spec.js
+++ b/test/EventStoreFactory/EventStoreFactory.spec.js
@@ -26,7 +26,7 @@ contract('EventStoreFactory', function (accounts) {
   it('Create EventStore', async () => {
     let _tx = await factory.createEventStore({ from: eventStoreCreator, gas: 2000000 })
     let _events = eventsFromTransaction(_tx)
-    assert.equal(_events[0].Type, 'EVENT_STORE_CREATED', 'EventStore Created Event is invalid')
+    assert.equal(_events[0].Type, 'FACTORY_EVENT_STORE_CREATED', 'EventStore Created Event is invalid')
     assert.equal(_events[1].AddressValue, eventStoreAddress, 'EventStore ContractAddress is invalid')
     assert.equal(_events[2].AddressValue, eventStoreCreator, 'EventStore ContractOwnerAddress is invalid')
   })
@@ -42,15 +42,10 @@ contract('EventStoreFactory', function (accounts) {
     assert.equal(_owner, factory.address, 'EventStoreFactory is not EventStore owner')
   })
 
-  it('Verify creatorEventStoreMapping update', async () => {
-    let _eventStoreAddress = await factory.getEventStoreByCreator.call({ from: eventStoreCreator })
-    assert.equal(_eventStoreAddress, eventStoreAddress, 'Address for creatorEventStoreMapping for not match EventStore address')
-  })
-
   it('Destroy EventStore', async () => {
     let _tx = await factory.killEventStore(eventStoreAddress, { from: eventStoreCreator })
     let _events = eventsFromTransaction(_tx)
-    assert.equal(_events[0].Type, 'EVENT_STORE_DESTROYED', 'EventStore Destroyed Event is invalid')
+    assert.equal(_events[0].Type, 'FACTORY_EVENT_STORE_DESTROYED', 'EventStore Destroyed Event is invalid')
     assert.equal(_events[1].AddressValue, eventStoreAddress, 'EventStore ContractAddress is invalid')
   })
 })


### PR DESCRIPTION
I'm starting a much larger upgrade to the event store to close some of the tougher open issues.

This version also supports multiple event stores by creator address, but that could use some more tests. and a better lookup interface.

we could implement a similar indexing pattern for the factory event stores as we have for events.

namely, a struct per creator that looks like this:

mapping (address => FactoryStore)

FactoryStore {
storeCount: uint;
mapping (uint => address)
}

getStoreByCreatorAndIndex(creatorAddress, index) => es contract address

I dont think a user will want to get all their event stores at once, and if they do, let them loop through them in middleware.

@eolszewski if you feel like implementing this, take over the branch, otherwise review this pr...
