### PR TITLE
Feature/ipld transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ If these fail, expect your PR to be rejected ; )
 - https://github.com/transmute-industries/eth-faucet
 - https://github.com/AugurProject/augur/blob/master/src/modules/auth/actions/register.js
 - https://airbitz.co/developer-api-library/
+
+

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
     "ethereumjs-util": "5.1.2",
     "firebase": "3.9.0",
     "flux-standard-action": "1.2.0",
+    "ipfs": "0.24.1",
+    "ipfs-api": "14.0.3",
+    "ipld": "^0.6.0",
+    "jiff": "^0.7.3",
     "json-logic-js": "1.1.1",
     "moment": "2.18.1",
     "ncp": "2.0.0",
@@ -77,9 +81,7 @@
     "typedoc": "0.7.1",
     "typescript": "2.3.4",
     "vorpal": "1.12.0",
-    "web3": "0.19.0",
-    "ipfs": "0.24.1",
-    "ipfs-api": "14.0.3"
+    "web3": "0.19.0"
   },
   "nyc": {
     "include": [

--- a/src/TransmuteIpfs/TransmuteIpfs.ts
+++ b/src/TransmuteIpfs/TransmuteIpfs.ts
@@ -121,7 +121,6 @@ export class TransmuteIpfsSingleton implements ITransmuteIpfs {
             for (var i = 0; i <= states.length - 2; i++) {
                 patches.push(jiff.diff(states[i], states[i + 1]))
             }
-            patches = _.flatten(patches)
             resolve(patches)
         })
     }
@@ -147,17 +146,17 @@ export class TransmuteIpfsSingleton implements ITransmuteIpfs {
         })
     }
 
-    // some thing is broken here...
-    applyIPLDHashes = async (stateObj, hashes) => {
-        let patches = await this.hashesToPatches(hashes)
-        let patched = jiff.patch(patches[0], stateObj) 
-
-        // console.log(patches)
-        // patches.forEach((patch) => {
-        //     patched = jiff.patch(patch, patched)
-        //     // console.log(patched)
-        // })
+    applyPatches = (obj, patches) => {
+        let patched = _.clone(obj)
+        patches.forEach((patch) => {
+            patched = jiff.patchInPlace(patch, patched)
+        })
         return patched
+    }
+
+    applyIPLDHashes = async (obj, hashes) => {
+        let patches = await this.hashesToPatches(hashes)
+        return this.applyPatches(obj, patches)
     }
 }
 

--- a/src/TransmuteIpfs/mock/config.json
+++ b/src/TransmuteIpfs/mock/config.json
@@ -1,3 +1,0 @@
-{
-    "hello": "world"
-}

--- a/src/TransmuteIpfs/mock/events/0.json
+++ b/src/TransmuteIpfs/mock/events/0.json
@@ -1,0 +1,14 @@
+{
+    "entityMap": {},
+    "blocks": [
+        {
+            "key": "ag6qs",
+            "text": "",
+            "type": "unstyled",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        }
+    ]
+}

--- a/src/TransmuteIpfs/mock/events/1.json
+++ b/src/TransmuteIpfs/mock/events/1.json
@@ -1,0 +1,32 @@
+{
+    "entityMap": {},
+    "blocks": [
+        {
+            "key": "ag6qs",
+            "text": "Hello World",
+            "type": "unstyled",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "fp3bl",
+            "text": "1",
+            "type": "unstyled",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "34t8c",
+            "text": "Welcome to IPFS and Ethreum",
+            "type": "unstyled",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        }
+    ]
+}

--- a/src/TransmuteIpfs/mock/events/2.json
+++ b/src/TransmuteIpfs/mock/events/2.json
@@ -1,0 +1,23 @@
+{
+    "entityMap": {},
+    "blocks": [
+        {
+            "key": "ag6qs",
+            "text": "Hello World!",
+            "type": "unstyled",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        },
+        {
+            "key": "34t8c",
+            "text": "Welcome to IPFS and Ethereum",
+            "type": "unstyled",
+            "depth": 0,
+            "inlineStyleRanges": [],
+            "entityRanges": [],
+            "data": {}
+        }
+    ]
+}


### PR DESCRIPTION
This PR implements some helper methods on TransmuteIpfs

Consider a state change in 2 large json objects: state1 and state2.

These helper methods allow for computing of a patch from state1 to state2.

This patch can then be saved to IPFS as IPLD.

Any JSON object state change can therefor be reconstructed from a base object (state1) and some number of IPLD hashes.

https://github.com/cujojs/jiff
https://www.npmjs.com/package/ipld

This allows for more compact representation of larger state changes on IPFS.